### PR TITLE
Fix for loop throwing a warning in MSVC

### DIFF
--- a/src/Archive.cpp
+++ b/src/Archive.cpp
@@ -2,14 +2,14 @@
 #include <algorithm>
 #include <map>
 
-#define calcPad32(x) (x + (32-1)) & ~(32-1)
+#define calcPad32(x) ((x + (32-1)) & ~(32-1))
 
 namespace Archive {
 
 const char ROOT_ID[5] = "ROOT";
 
 void padTo32(bStream::CStream* stream, size_t size){
-    for(int i = 0; i < (size + (32-1)) & ~(32-1); i++) stream->writeUInt8(0);
+    for(int i = 0; i < calcPad32(size); i++) stream->writeUInt8(0);
 }
 
 uint16_t Hash(std::string str){


### PR DESCRIPTION
The `i < (size + (32-1)) & ~(32-1)` was causing a issue where the the & was being promoted to a bool I think, so I updated the macro and the for loop. We could honestly make `calcPad32` a template, but that can be another time.